### PR TITLE
Add hypervisor skill

### DIFF
--- a/resume.yml
+++ b/resume.yml
@@ -80,6 +80,8 @@ skills:
     keywords: ["Python", "Go", "Java", "TypeScript", "C++", "Rust"]
   - name: "Monitoring"
     keywords: ["Grafana", "Prometheus", "ELK"]
+  - name: "Hyperviseur"
+    keywords: ["Nutanix"]
   - name: "Methodology"
     keywords: ["Agile", "Scrum", "Jira", "Confluence", "V-Model"]
 


### PR DESCRIPTION
## Summary
- list Nutanix under a new **Hyperviseur** skill category in `resume.yml`

## Testing
- `make test` *(fails: PDF not found)*

------
https://chatgpt.com/codex/tasks/task_e_684279bf5c88832da8f133db28959d96